### PR TITLE
Wrong expander

### DIFF
--- a/Containers/cljdetector/src/cljdetector/core.clj
+++ b/Containers/cljdetector/src/cljdetector/core.clj
@@ -34,7 +34,7 @@
     (storage/identify-candidates!)
     (ts-println "Found" (storage/count-items "candidates") "candidates")
     (ts-println "Expanding Candidates...")
-    (expander/expand-clones)))
+    (expander/expand-clones-elegantly)))
 
 (defn pretty-print [clones]
   (doseq [clone clones]


### PR DESCRIPTION
I think the [documentation](https://github.com/mickesv/BigDataAnalytics/blob/main/Documentation/Big-Data-Analytics.org#first-run-on-full-qualitas-corpus) is not so clear about the code (and can be quite challenging for someone not familiar with lisp/clojure). 

First, reading the documentation, I assumed that the elegant expander is used (which is currently not the case). If I'm wrong, this patch can be ignored. 

Second, the documentation refers to the _first-expand-then-store-all_ relic. What is that?